### PR TITLE
Update athena-workgroup module

### DIFF
--- a/modules/athena-workgroup/main.tf
+++ b/modules/athena-workgroup/main.tf
@@ -44,7 +44,8 @@ resource "aws_athena_workgroup" "this" {
       for_each = local.query_result_s3_path != null ? ["go"] : []
 
       content {
-        output_location = local.query_result_s3_path
+        output_location       = local.query_result_s3_path
+        expected_bucket_owner = try(var.query_result.s3_bucket_expected_owner, null)
 
         dynamic "encryption_configuration" {
           for_each = try(var.query_result.encryption_enabled, false) ? ["go"] : []
@@ -52,6 +53,14 @@ resource "aws_athena_workgroup" "this" {
           content {
             encryption_option = try(var.query_result.encryption_mode, "SSE_S3")
             kms_key_arn       = try(var.query_result.encryption_kms_key, null)
+          }
+        }
+
+        dynamic "acl_configuration" {
+          for_each = try(var.query_result.s3_bucket_owner_full_control_enabled, false) ? ["go"] : []
+
+          content {
+            s3_acl_option = "BUCKET_OWNER_FULL_CONTROL"
           }
         }
       }

--- a/modules/athena-workgroup/outputs.tf
+++ b/modules/athena-workgroup/outputs.tf
@@ -55,6 +55,9 @@ output "query_result" {
     s3_key_prefix = local.query_result_s3_key_prefix
     s3_path       = local.query_result_s3_path
 
+    s3_bucket_expected_owner             = try(var.query_result.s3_bucket_expected_owner, null)
+    s3_bucket_owner_full_control_enabled = try(var.query_result.s3_bucket_owner_full_control_enabled, false)
+
     encryption_enabled = try(var.query_result.encryption_enabled, false)
     encryption_mode    = try(aws_athena_workgroup.this.configuration[0].result_configuration[0].encryption_configuration[0].encryption_option, null)
     encryption_kms_key = try(aws_athena_workgroup.this.configuration[0].result_configuration[0].encryption_configuration[0].kms_key_arn, null)

--- a/modules/athena-workgroup/variables.tf
+++ b/modules/athena-workgroup/variables.tf
@@ -49,6 +49,8 @@ variable "query_result" {
   (Optional) The configuration for query result location and encryption. A `query_result` block as defined below.
     (Required) `s3_bucket` - The name of the S3 bucket used to store the query result.
     (Optional) `s3_key_prefix` - The key prefix for the specified S3 bucket. Defaults to `null`.
+    (Optional) `s3_bucket_expected_owner` - The AWS account ID that you expect to be the owner of the Amazon S3 bucket.
+    (Optional) `s3_bucket_owner_full_control_enabled` - Enabling this option grants the owner of the S3 query results bucket full control over the query results. This means that if your query result location is owned by another account, you grant full control over your query results to the other account.
     (Optional) `encryption_enabled` - Whether to encrypt query results on S3 bucket.
     (Optional) `encryption_mode` - Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (SSE_S3), server-side encryption with KMS-managed keys (SSE_KMS), or client-side encryption with KMS-managed keys (CSE_KMS) is used. If a query runs in a workgroup and the workgroup overrides client-side settings, then the workgroup's setting for encryption is used.
     (Optional) `encryption_kms_key` - For `SSE_KMS` and `CSE_KMS` encryption modes, this is the KMS key Amazon Resource Name (ARN).

--- a/modules/athena-workgroup/versions.tf
+++ b/modules/athena-workgroup/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71"
+      version = ">= 4.7"
     }
   }
 }


### PR DESCRIPTION
### Background

- Support `acl_configuration` and `expected_bucket_owner` arguments to the `configuration.result_configuration` block

### Related Issues

- Close #8 