### PR TITLE
feat: add permissions_boundary support for IAM roles

### DIFF
--- a/modules/athena-workgroup/iam.tf
+++ b/modules/athena-workgroup/iam.tf
@@ -45,6 +45,8 @@ module "role__iam_identity_center" {
     var.iam_identity_center.default_service_role.inline_policies
   )
 
+  permissions_boundary = var.iam_identity_center.default_service_role.permissions_boundary
+
   force_detach_policies = true
   resource_group = {
     enabled = false

--- a/modules/athena-workgroup/variables.tf
+++ b/modules/athena-workgroup/variables.tf
@@ -143,18 +143,20 @@ variable "iam_identity_center" {
       (Optional) `description` - The description of the IAM Role. Defaults to `Managed by Terraform.`.
       (Optional) `policies` - A list of IAM Policy ARNs to attach to the IAM Role. Defaults to an empty list.
       (Optional) `inline_policies` - A map of names to inline policy documents to attach to the IAM Role. Defaults to an empty map.
+      (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default IAM Role.
     (Optional) `service_role` - The Amazon Resource Name (ARN) of the IAM Role to be used by workgroup members authenticated via IAM Identity Center. Only required if `default_service_role.enabled` is `false`.
   EOF
   type = object({
     enabled  = optional(bool, false)
     instance = optional(string)
     default_service_role = optional(object({
-      enabled         = optional(bool, true)
-      name            = optional(string)
-      path            = optional(string, "/")
-      description     = optional(string, "Managed by Terraform.")
-      policies        = optional(list(string), [])
-      inline_policies = optional(map(string), {})
+      enabled              = optional(bool, true)
+      name                 = optional(string)
+      path                 = optional(string, "/")
+      description          = optional(string, "Managed by Terraform.")
+      policies             = optional(list(string), [])
+      inline_policies      = optional(map(string), {})
+      permissions_boundary = optional(string)
     }), {})
     service_role = optional(string)
   })

--- a/modules/glue-crawler/iam.tf
+++ b/modules/glue-crawler/iam.tf
@@ -52,6 +52,8 @@ module "role" {
     var.default_service_role.inline_policies
   )
 
+  permissions_boundary = var.default_service_role.permissions_boundary
+
   force_detach_policies = true
   resource_group = {
     enabled = false

--- a/modules/glue-crawler/variables.tf
+++ b/modules/glue-crawler/variables.tf
@@ -183,7 +183,7 @@ variable "iceberg_data_sources" {
 variable "jdbc_data_sources" {
   description = <<EOF
   (Optional) A list of JDBC data sources to be scanned by the crawler. Each item of `jdbc_data_sources` as defined below.
-    (Required) `path` - The path of the JDBC data source. Use `<database>/<schema>/<table>` or `<database>/<table>` format, depending on the database product. Oracle Database and MySQL don’t support schema in the path. You can substitute the percent `%` character for `<schema>` or `<table>`. For example, for an Oracle database with a system identifier (SID) of orcl, enter `orcl/%` to import all tables to which the user named in the connection has access.
+    (Required) `path` - The path of the JDBC data source. Use `<database>/<schema>/<table>` or `<database>/<table>` format, depending on the database product. Oracle Database and MySQL don't support schema in the path. You can substitute the percent `%` character for `<schema>` or `<table>`. For example, for an Oracle database with a system identifier (SID) of orcl, enter `orcl/%` to import all tables to which the user named in the connection has access.
     (Optional) `connection` - The name of the connection to use to connect to the JDBC data source.
     (Optional) `exclusion_patterns` - A list of glob patterns used to exclude from the crawl.
     (Optional) `additional_metadata_properties` - A set of additional metadata properties for the crawler to crawl. Valid values are `RAWTYPES` and `COMMENTS` to enable additional metadata in table responses.
@@ -353,6 +353,7 @@ variable "default_service_role" {
     (Optional) `description` - The description of the default service role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default service role. `AWSGlueServiceRole` is always attached. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default service role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default service role.
   EOF
   type = object({
     enabled     = optional(bool, true)
@@ -360,8 +361,9 @@ variable "default_service_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false

--- a/modules/s3-bucket/iam.tf
+++ b/modules/s3-bucket/iam.tf
@@ -64,6 +64,8 @@ module "replication_iam_role" {
     ))
   }, var.default_replication_iam_role.inline_policies)
 
+  permissions_boundary = var.default_replication_iam_role.permissions_boundary
+
   force_detach_policies = true
   resource_group = {
     enabled = false

--- a/modules/s3-bucket/variables.tf
+++ b/modules/s3-bucket/variables.tf
@@ -194,6 +194,7 @@ variable "default_replication_iam_role" {
     (Optional) `description` - The description of the default replication IAM role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default replication IAM role. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default replication IAM role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default replication IAM role.
   EOF
   type = object({
     enabled     = optional(bool, true)
@@ -201,8 +202,9 @@ variable "default_replication_iam_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
## Summary

This PR adds `permissions_boundary` parameter support to IAM roles in modules that use the `terraform-aws-account` `iam-role` module. This allows users to configure IAM permissions boundaries for better security control.

## Changes

### modules/s3-bucket
- **iam.tf**: Added `permissions_boundary` parameter to `module "replication_iam_role"`
- **variables.tf**: Added `permissions_boundary = optional(string)` to `default_replication_iam_role` variable

### modules/athena-workgroup
- **iam.tf**: Added `permissions_boundary` parameter to `module "role__iam_identity_center"`
- **variables.tf**: Added `permissions_boundary = optional(string)` to `iam_identity_center.default_service_role` variable

### modules/glue-crawler
- **iam.tf**: Added `permissions_boundary` parameter to `module "role"`
- **variables.tf**: Added `permissions_boundary = optional(string)` to `default_service_role` variable

## Reference

This change follows the pattern established in: https://github.com/tedilabs/terraform-aws-security/commit/a65368004de7769c5bc281d255293c1c734743ed