### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/athena-workgroup/main.tf
+++ b/examples/athena-workgroup/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "simple" {
   source = "../../modules/athena-workgroup"
   # source  = "tedilabs/data/aws//modules/athena-workgroup"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name = "simple"
 
@@ -27,7 +27,7 @@ module "simple" {
 module "full" {
   source = "../../modules/athena-workgroup"
   # source  = "tedilabs/data/aws//modules/athena-workgroup"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name        = "full"
   description = "This workgroup is created with full configurtaions."

--- a/examples/glue-data-catalog-full/main.tf
+++ b/examples/glue-data-catalog-full/main.tf
@@ -91,7 +91,7 @@ locals {
 
 module "kms_key" {
   source  = "tedilabs/secret/aws//modules/kms-key"
-  version = "~> 0.3.0"
+  version = "~> 0.7.0"
 
   name        = "example-glue"
   aliases     = ["alias/example-glue"]
@@ -117,7 +117,7 @@ module "kms_key" {
 module "data_catalog" {
   source = "../../modules/glue-data-catalog"
   # source  = "tedilabs/data/aws//modules/glue-data-catalog"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   policy = data.aws_iam_policy_document.this.json
 
@@ -143,7 +143,7 @@ module "data_catalog" {
 module "database" {
   source = "../../modules/glue-database"
   # source  = "tedilabs/data/aws//modules/glue-database"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   for_each = {
     for database in try(local.databases, []) :
@@ -169,7 +169,7 @@ module "database" {
 module "table" {
   source = "../../modules/glue-table"
   # source  = "tedilabs/data/aws//modules/glue-table"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   for_each = {
     for table in try(local.tables, []) :

--- a/examples/glue-data-catalog-full/versions.tf
+++ b/examples/glue-data-catalog-full/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.12"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/glue-data-catalog-full/versions.tf
+++ b/examples/glue-data-catalog-full/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 6.13"
     }
   }
 }

--- a/examples/glue-data-catalog-simple/main.tf
+++ b/examples/glue-data-catalog-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "data_catalog" {
   source = "../../modules/glue-data-catalog"
   # source  = "tedilabs/data/aws//modules/glue-data-catalog"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   encryption_for_connection_passwords = {
     enabled = false
@@ -32,7 +32,7 @@ module "data_catalog" {
 module "database" {
   source = "../../modules/glue-database"
   # source  = "tedilabs/data/aws//modules/glue-database"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name = "example"
 
@@ -49,7 +49,7 @@ module "database" {
 module "table" {
   source = "../../modules/glue-table"
   # source  = "tedilabs/data/aws//modules/glue-table"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   database = module.database.name
   name     = "helloworld"

--- a/examples/s3-access-point-internet/main.tf
+++ b/examples/s3-access-point-internet/main.tf
@@ -28,7 +28,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true
@@ -46,7 +46,7 @@ module "bucket" {
 module "access_point" {
   source = "../../modules/s3-access-point"
   # source  = "tedilabs/data/aws//modules/s3-access-point"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name = local.access_point_name
   bucket = {

--- a/examples/s3-access-point-vpc/main.tf
+++ b/examples/s3-access-point-vpc/main.tf
@@ -32,7 +32,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true
@@ -50,7 +50,7 @@ module "bucket" {
 module "access_point" {
   source = "../../modules/s3-access-point"
   # source  = "tedilabs/data/aws//modules/s3-access-point"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name = local.access_point_name
   bucket = {

--- a/examples/s3-bucket-access-logging/main.tf
+++ b/examples/s3-bucket-access-logging/main.tf
@@ -21,7 +21,7 @@ locals {
 module "source_bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = "${local.bucket_name}-source"
   force_destroy = true
@@ -40,7 +40,7 @@ module "source_bucket" {
 module "target_bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = "${local.bucket_name}-target"
   force_destroy = true

--- a/examples/s3-bucket-encryption/main.tf
+++ b/examples/s3-bucket-encryption/main.tf
@@ -22,7 +22,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = "${local.bucket_name}-aes256"
   force_destroy = true
@@ -40,7 +40,7 @@ module "bucket" {
 module "bucket_kms" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = "${local.bucket_name}-aws-kms"
   force_destroy = true
@@ -58,7 +58,7 @@ module "bucket_kms" {
 
 module "kms_key" {
   source  = "tedilabs/secret/aws//modules/kms-key"
-  version = "~> 0.3.0"
+  version = "~> 0.7.0"
 
   name = local.kms_key_name
 

--- a/examples/s3-bucket-encryption/versions.tf
+++ b/examples/s3-bucket-encryption/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 6.23"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-encryption/versions.tf
+++ b/examples/s3-bucket-encryption/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.12"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-full/main.tf
+++ b/examples/s3-bucket-full/main.tf
@@ -21,7 +21,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true
@@ -149,7 +149,7 @@ module "bucket" {
 module "log_bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = "${local.bucket_name}-log"
   force_destroy = true

--- a/examples/s3-bucket-lifecycle-rules/main.tf
+++ b/examples/s3-bucket-lifecycle-rules/main.tf
@@ -21,7 +21,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true

--- a/examples/s3-bucket-objects/main.tf
+++ b/examples/s3-bucket-objects/main.tf
@@ -21,7 +21,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.7.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true

--- a/examples/s3-bucket-versioning/main.tf
+++ b/examples/s3-bucket-versioning/main.tf
@@ -21,7 +21,7 @@ locals {
 module "bucket" {
   source = "../../modules/s3-bucket"
   # source  = "tedilabs/data/aws//modules/s3-bucket"
-  # version = "~> 0.2.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true

--- a/examples/s3-table-bucket/main.tf
+++ b/examples/s3-table-bucket/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "table_bucket" {
 module "table_bucket" {
   source = "../../modules/s3-table-bucket"
   # source  = "tedilabs/data/aws//modules/s3-table-bucket"
-  # version = "~> 0.7.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "table" {
 module "table" {
   source = "../../modules/s3-table"
   # source  = "tedilabs/data/aws//modules/s3-table"
-  # version = "~> 0.7.0"
+  # version = "~> 0.8.0"
 
   table_bucket = module.table_bucket.arn
   namespace    = module.table_bucket.namespaces["analytics"].name

--- a/examples/s3-vector-bucket/main.tf
+++ b/examples/s3-vector-bucket/main.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "this" {
 module "vector_bucket" {
   source = "../../modules/s3-vector-bucket"
   # source  = "tedilabs/data/aws//modules/s3-vector-bucket"
-  # version = "~> 0.7.0"
+  # version = "~> 0.8.0"
 
   name          = local.bucket_name
   force_destroy = true

--- a/modules/glue-data-catalog/ram-shares.tf
+++ b/modules/glue-data-catalog/ram-shares.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :

--- a/modules/glue-database/ram-shares.tf
+++ b/modules/glue-database/ram-shares.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :

--- a/modules/glue-table/ram-shares.tf
+++ b/modules/glue-table/ram-shares.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :

--- a/modules/s3-bucket/iam.tf
+++ b/modules/s3-bucket/iam.tf
@@ -14,7 +14,7 @@ module "replication_iam_role" {
   count = length(var.replication_rules) > 0 && var.default_replication_iam_role.enabled ? 1 : 0
 
   source  = "tedilabs/account/aws//modules/iam-role"
-  version = "~> 0.32.0"
+  version = "~> 0.33.0"
 
   name = coalesce(
     var.default_replication_iam_role.name,


### PR DESCRIPTION
## What & why

The `version` constraints on sibling `tedilabs/*` child modules in this repo had drifted well behind those modules' latest releases, and the commented registry snippets in `examples/` still advertised `~> 0.2.0` of this repo's own modules. This realigns every constraint to the house `~> MAJOR.MINOR.0` minor-floor convention against the current releases, and adapts the two example roots that call `secret/aws//modules/kms-key` to that module's new version floors.

No resource logic changed — only version constraints, plus the `versions.tf` floors of the two example roots that were blocking the new `kms-key` from resolving.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/secret/aws//modules/kms-key` | `examples/glue-data-catalog-full/main.tf` | `~> 0.3.0` | `~> 0.7.0` | `v0.7.1` |
| `tedilabs/secret/aws//modules/kms-key` | `examples/s3-bucket-encryption/main.tf` | `~> 0.3.0` | `~> 0.7.0` | `v0.7.1` |
| `tedilabs/organization/aws//modules/ram-share` | `modules/glue-data-catalog/ram-shares.tf` | `~> 0.5.0` | `~> 0.7.0` | `v0.7.5` |
| `tedilabs/organization/aws//modules/ram-share` | `modules/glue-database/ram-shares.tf` | `~> 0.5.0` | `~> 0.7.0` | `v0.7.5` |
| `tedilabs/organization/aws//modules/ram-share` | `modules/glue-table/ram-shares.tf` | `~> 0.5.0` | `~> 0.7.0` | `v0.7.5` |
| `tedilabs/account/aws//modules/iam-role` | `modules/s3-bucket/iam.tf` | `~> 0.32.0` | `~> 0.33.0` | `v0.33.10` |

Supporting change (not a module constraint) — root version floors of the two example roots that call `kms-key`:

| Path | Before | After |
|---|---|---|
| `examples/glue-data-catalog-full/versions.tf` | `required_version = "~> 1.5"`, `aws = "~> 4.0"` | `required_version = ">= 1.12"`, `aws = ">= 6.13"` |
| `examples/s3-bucket-encryption/versions.tf` | `required_version = "~> 1.5"`, `aws = "~> 4.0"` | `required_version = ">= 1.12"`, `aws = ">= 6.23"` |

Both floors were already unsatisfiable before this PR — the local `../../modules/*` these examples reference require Terraform `>= 1.12` with aws `>= 6.13` / `>= 6.23`. `kms-key` v0.7.x adds the same requirement (`>= 1.12` / aws `>= 6.12`), so raising them here is what makes these two roots initialisable again. Other `examples/*` roots still carry the stale `~> 1.5` / `~> 4.0` floors; they are untouched here because no constraint in them changed, and fixing them is a separate cleanup.

### Example docs (commented registry alternatives)

All 24 are self-references to this repo's own modules (`tedilabs/data/aws//modules/*`). Active `source` in these blocks remains the local `../../modules/x` path; only the commented `# version` line moved. Latest release of this repo is `v0.8.0`.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `athena-workgroup` | `examples/athena-workgroup/main.tf` (x2) | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `glue-data-catalog` | `examples/glue-data-catalog-full/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `glue-database` | `examples/glue-data-catalog-full/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `glue-table` | `examples/glue-data-catalog-full/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `glue-data-catalog` | `examples/glue-data-catalog-simple/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `glue-database` | `examples/glue-data-catalog-simple/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `glue-table` | `examples/glue-data-catalog-simple/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-access-point-internet/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-access-point` | `examples/s3-access-point-internet/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-access-point-vpc/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-access-point` | `examples/s3-access-point-vpc/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-bucket-access-logging/main.tf` (x2) | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-bucket-encryption/main.tf` (x2) | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-bucket-full/main.tf` (x2) | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-bucket-lifecycle-rules/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-bucket-objects/main.tf` | `~> 0.7.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-bucket` | `examples/s3-bucket-versioning/main.tf` | `~> 0.2.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-table-bucket` | `examples/s3-table-bucket/main.tf` | `~> 0.7.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-table` | `examples/s3-table-bucket/main.tf` | `~> 0.7.0` | `~> 0.8.0` | `v0.8.0` |
| `s3-vector-bucket` | `examples/s3-vector-bucket/main.tf` | `~> 0.7.0` | `~> 0.8.0` | `v0.8.0` |

## Interface changes between the old and new versions

### `tedilabs/organization/aws//modules/ram-share` — v0.5.6 → v0.7.5

Compare: https://github.com/tedilabs/terraform-aws-organization/compare/v0.5.6...v0.7.5

**Verdict: no interface change.** No variables added, removed, renamed or retyped; no output changes; no new Terraform or provider floor. The entire `modules/ram-share` directory is byte-identical between the two tags — the module directory's git tree object is the same hash (`63ef8ac7…`) at both, `git diff v0.5.6..v0.7.5 -- modules/ram-share/` is empty, and no commit between the tags touched the path. `versions.tf` already declared `>= 1.12` / aws `>= 6.12` at v0.5.6, so nothing new is imposed on callers.

This is a pure constraint bump. No calling code in this repo changed.

### `tedilabs/account/aws//modules/iam-role` — v0.32.1 → v0.33.10

Compare: https://github.com/tedilabs/terraform-aws-account/compare/v0.32.1...v0.33.10

**Verdict: no interface change** for this specific range. `variables.tf`, `outputs.tf` and `versions.tf` are byte-identical at both tags; the only changed files are `README.md` and `main.tf`. Floors stay at Terraform `>= 1.12` / aws `>= 6.12`. No variables or outputs added, removed or renamed.

This is a pure constraint bump — no calling code in `modules/s3-bucket` changed.

**Plan-review note (behavioural, no code change needed):** the generated `assume_role` inline policy widened its action list from `["sts:AssumeRole"]` to `["sts:AssumeRole", "sts:TagSession", "sts:SetSourceIdentity"]`. Any caller that sets `assumable_roles` will see an in-place update of `aws_iam_role_policy.assume_role` granting those two extra actions. In `modules/s3-bucket` the role is the optional default replication role (`module.replication_iam_role`, gated on `length(var.replication_rules) > 0 && var.default_replication_iam_role.enabled`), so this only surfaces for buckets that actually use it. Worth confirming the permission widening is acceptable before applying.

### `tedilabs/secret/aws//modules/kms-key` — v0.3.0 → v0.7.1

Compare: https://github.com/tedilabs/terraform-aws-secret/compare/v0.3.0...v0.7.1

**Verdict: action required** in general — but see below for what actually applied to these two call sites.

Added variables (all defaulted, none required): `region`, `key_rotation` (object), `grants`, `predefined_policies`, `custom_key_store`, `xks_key`, `resource_group` (object).

Removed variables (breaking only if set): `key_rotation_enabled` → `key_rotation.enabled`; `resource_group_enabled` / `resource_group_name` / `resource_group_description` → collapsed into the `resource_group` object.

Retyped: `aliases` `list(string)` → `set(string)` (auto-converts, and the `for_each` key set is unchanged, so no state churn). `name` gained `nullable = false`.

Removed outputs: `key_rotation_enabled` (superseded by the `key_rotation` object) and `bypass_policy_lockout_safety_check` (no replacement). Added: `region`, `description`, `custom_key_store`, `xks_key`, `key_rotation`, `grants`, `predefined_policies`, `resource_group`. The `policy` output changed source from `aws_kms_key.this.policy` to `one(aws_kms_key_policy.this[*].policy)` and is now `null` when neither `policy` nor `predefined_policies` is set.

New floors: Terraform `>= 1.2` → `>= 1.12`; `hashicorp/aws` `>= 4.22` → `>= 6.12`. The module also gained a nested registry dependency on `tedilabs/misc/aws//modules/resource-group ~> 0.12.0`.

**What actually changed in this repo's calling code:** only the version floors in the two example roots' `versions.tf` (item 4 of the upstream caller-action list). Nothing else applied:

- Neither call site sets `key_rotation_enabled`, so no rename was needed.
- Neither call site sets any `resource_group_*` variable.
- Neither example's `outputs.tf` references a removed output — both re-export the whole module object (`value = module.kms_key`), which is unaffected by the added/removed attributes.
- `examples/glue-data-catalog-full` passes `aliases = ["alias/example-glue"]` (list → set auto-conversion, fine), an explicit `description = "Managed by Terraform."` (which happens to match the new default, so no plan diff there) and `policy = null` (variable still exists).

**Plan-review notes for real consumers of these examples** (documented upstream, no code change here):

- The key policy moves off `aws_kms_key` onto a new `aws_kms_key_policy.this[0]` resource. If neither `policy` nor `predefined_policies` is set, no `aws_kms_key_policy` is created and a previously-managed inline policy stops being managed.
- Resource-group state migration is handled by the module's own `migrations.tf` `moved` block — no manual `terraform state mv`. Expect an in-place update on the resource group (query shape changed, `"Name"` tag no longer added).
- Callers that never set `description` will see the key description change to `"Managed by Terraform."`.

## Verification

- `terraform fmt -recursive -check .` — **pass**, no reformatting needed.
- `examples/glue-data-catalog-full`: `terraform init -backend=false` + `terraform validate` — **Success** (one pre-existing warning unrelated to this PR: `data.aws_region.this.name` is deprecated in favour of `region`; left alone as out of scope). `init` resolved `kms-key` to **v0.7.1**, all three `ram-share` instances (`data_catalog.share`, `database.share`, `table.share`) to **v0.7.5**, and the nested `misc/aws//modules/resource-group` to v0.12.0 — so this run exercises all three `ram-share` call sites and the `kms-key` bump together.
- `examples/s3-bucket-encryption`: `terraform init -backend=false` + `terraform validate` — **Success**, no warnings. `init` resolved `kms-key` to **v0.7.1** and `account/aws//modules/iam-role` to **v0.33.10** via `modules/s3-bucket`, so this run covers the `iam-role` bump.
- Between them, these two roots transitively cover every changed `modules/*` directory (`glue-data-catalog`, `glue-database`, `glue-table`, `s3-bucket`), so the `modules/*` dirs were not validated standalone.
- `.terraform/` and `.terraform.lock.hcl` were removed from both directories afterwards; `git status --porcelain` confirmed only the intended `.tf` files are staged.

Not verified:

- No `terraform plan` or `apply` was run, so the behavioural notes above (the widened `assume_role` actions, the KMS key policy resource split, the resource-group in-place update, the key description default) are read from the upstream source and diffs, not from an executed plan. **Please review a real plan in a consuming stack before applying.**
- The other `examples/*` roots still on `required_version = "~> 1.5"` / aws `~> 4.0` were not initialised or validated — they were already unsatisfiable against the local modules they reference, which is pre-existing and out of scope for this PR.
- Local environment note: the initial `init` picked up a `hashicorp/aws` 6.58.0 package from the shared plugin cache whose checksum did not match the freshly generated lock file. Both dirs were re-initialised against a clean throwaway `TF_PLUGIN_CACHE_DIR` to get the successful validations above. This is a local workstation cache artefact, not something in this repo.

## Supersedes

Open dependabot PRs covering some of the same constraints. This PR supersedes them because dependabot pins the exact patch release rather than the house `~> MAJOR.MINOR.0` minor-floor convention, and it does not touch `examples/`:

- **#87** — `tedilabs/organization/aws` `~> 0.5.0` → `~> 0.6.4` in `/modules/glue-data-catalog`. Superseded: this PR uses `~> 0.7.0` (v0.7.5 is the latest release, so `~> 0.6.4` is both an exact-patch pin *and* already a minor behind).
- **#88** — same, in `/modules/glue-database`. Superseded for the same reason. Note dependabot opened PRs for only two of the three `ram-share` call sites; `modules/glue-table/ram-shares.tf` was left behind and is included here.
- **#90** — `tedilabs/account/aws` `~> 0.32.0` → `~> 0.33.5` in `/modules/s3-bucket`. Superseded: this PR uses `~> 0.33.0`.

Not superseded, but checked while here:

- **#75** — `tedilabs/account/aws` `~> 0.25.0` → `~> 0.33.2` in `/modules/glue-crawler`. **Already current on `main`:** `modules/glue-crawler/iam.tf` is at `~> 0.33.0`, so this PR makes no change there and #75 is stale rather than superseded.
- **#58** — `tedilabs/misc/aws` `~> 0.10.0` → `~> 0.11.0` in `/modules/s3-bucket`. Also stale: every `resource-group` reference in this repo is already at `~> 0.12.0` (the current release), so no `misc/aws` constraint needed changing.

These dependabot PRs are intentionally left open for a maintainer to close.
