### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/athena-workgroup/versions.tf
+++ b/examples/athena-workgroup/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/glue-data-catalog-simple/versions.tf
+++ b/examples/glue-data-catalog-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/s3-access-point-internet/versions.tf
+++ b/examples/s3-access-point-internet/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-access-point-vpc/versions.tf
+++ b/examples/s3-access-point-vpc/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-access-logging/versions.tf
+++ b/examples/s3-bucket-access-logging/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-full/versions.tf
+++ b/examples/s3-bucket-full/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-lifecycle-rules/versions.tf
+++ b/examples/s3-bucket-lifecycle-rules/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-objects/versions.tf
+++ b/examples/s3-bucket-objects/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.12"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-bucket-versioning/versions.tf
+++ b/examples/s3-bucket-versioning/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-table-bucket/versions.tf
+++ b/examples/s3-table-bucket/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.12"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.57"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-vector-bucket/versions.tf
+++ b/examples/s3-vector-bucket/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.12"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.57"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## What & why

Eight example roots in this repo pin an `aws` provider upper bound (`~> 4.0`, i.e. `< 5.0.0`) that is
*below* the lower bound their own local modules declare (`>= 6.13`, `>= 6.23`, `>= 6.25`, `>= 6.57`).
The constraint set has an empty intersection, so `terraform init` cannot resolve a provider at all and
these examples are simply unusable. A real error, verbatim:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 4.0, >= 4.22.0, >=
6.0.0, >= 6.12.0, >= 6.23.0, >= 6.57.0
```

Three further roots already resolved, but expressed their constraints with `>=` (`required_version = ">= 1.12"`,
`aws = ">= 6.23"` / `">= 6.57"`), which is inconsistent with the convention used everywhere else.

This PR touches **only** `examples/*/versions.tf`.

## Convention applied

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `aws = "~> 6.0"`; `random` was already `~> 3.0` and is left alone

`~> 6.0` is sufficient even though modules declare floors as high as `>= 6.57`: Terraform intersects
every constraint in the module graph, so `~> 6.0` ∩ `>= 6.57` = `[6.57, 7.0)`. No minor floor needs to
be duplicated into the root. Confirmed empirically below — every root resolved to **aws v6.58.0**.

## Changed roots

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/athena-workgroup` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.25`) |
| `examples/glue-data-catalog-simple` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.13`) |
| `examples/s3-access-point-internet` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.23`) |
| `examples/s3-access-point-vpc` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.23`) |
| `examples/s3-bucket-access-logging` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.23`) |
| `examples/s3-bucket-full` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.23`) |
| `examples/s3-bucket-lifecycle-rules` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.23`) |
| `examples/s3-bucket-versioning` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (module needs `>= 6.23`) |
| `examples/s3-bucket-objects` | `>= 1.12` → `~> 1.12` | `>= 6.23` → `~> 6.0` | style only |
| `examples/s3-table-bucket` | `>= 1.12` → `~> 1.12` | `>= 6.57` → `~> 6.0` | style only |
| `examples/s3-vector-bucket` | `>= 1.12` → `~> 1.12` | `>= 6.57` → `~> 6.0` | style only |

8 init-breaking conflicts, 3 style-only. `hashicorp/random` blocks already conformed at `~> 3.0` and
were not modified.

## Verification

`terraform fmt -recursive -check .` — passes.

Per root, `terraform init -backend=false` then `terraform validate` (Terraform v1.15.6, serial runs,
dedicated `TF_PLUGIN_CACHE_DIR`):

| Example root | Result | aws resolved |
| --- | --- | --- |
| `examples/athena-workgroup` | **init FAILS** — pre-existing HCL error, see below | n/a (aborts before provider resolution) |
| `examples/glue-data-catalog-simple` | init OK, validate OK | v6.58.0 |
| `examples/s3-access-point-internet` | init OK, validate OK (deprecation warning) | v6.58.0 |
| `examples/s3-access-point-vpc` | init OK, validate OK (deprecation warning) | v6.58.0 |
| `examples/s3-bucket-access-logging` | init OK, validate OK | v6.58.0 |
| `examples/s3-bucket-full` | init OK, validate OK | v6.58.0 |
| `examples/s3-bucket-lifecycle-rules` | init OK, validate OK | v6.58.0 |
| `examples/s3-bucket-objects` | init OK, validate OK | v6.58.0 |
| `examples/s3-bucket-versioning` | init OK, validate OK | v6.58.0 |
| `examples/s3-table-bucket` | init OK, validate OK | v6.58.0 |
| `examples/s3-vector-bucket` | init OK, validate OK | v6.58.0 |

10 of 11 roots are green. Notes:

- The three style-only roots confirm the intersection argument: with the root at `~> 6.0`, the module
  floor `>= 6.57` still applies and `init` selected v6.58.0. Recorded constraint set for
  `examples/s3-vector-bucket`: `">= 6.0.0, ~> 6.0, >= 6.57.0"` → `6.58.0`.
- The two `s3-access-point-*` warnings are pre-existing and unrelated to versions:
  `name is deprecated. Use region instead.` on `data.aws_region.this.name`. Warnings only; validate
  still succeeds.

## Pre-existing failures newly exposed

`examples/athena-workgroup` previously failed at provider resolution, so its HCL was never checked.
With the constraint fixed, `init` gets further and now surfaces a stale module argument:

```
Error: Unsupported argument

  on main.tf line 38, in module "full":
  38:   client_config_enabled                     = false

An argument named "client_config_enabled" is not expected here.
```

`client_config_enabled` is not declared by `modules/athena-workgroup` (it appears nowhere under
`modules/`). This is a pre-existing bug in the example, **not** caused by this PR, and it is
deliberately left unfixed here — stale example arguments are a separate piece of work. It is also
*not* covered by PR #95, even though that PR does touch `examples/athena-workgroup/main.tf`.

**CI will therefore still be red for `examples/athena-workgroup`.** This PR does not claim to make
that root green; it only removes the constraint conflict that was masking the real problem.

## Related PRs

- **#95 — `chore/deps-align-child-module-versions`** (open). It fixes the same class of constraint
  conflict for the two roots deliberately **excluded** from this PR: `examples/glue-data-catalog-full`
  and `examples/s3-bucket-encryption`. Those two `versions.tf` files are intentionally untouched here
  to avoid a merge conflict, which means **both PRs are needed for the repo's examples to be fully
  clean.** Aside from those two files, #95 changes only `examples/*/main.tf` and `modules/**` — the
  file sets are otherwise disjoint and the two PRs can merge in either order.
- No `docs/align-readme-example-versions` PR exists in this repo.
- Open dependabot PRs (#75, #87, #88, #90) touch `modules/**` and `.github/**` only — no overlap.
