### PR TITLE
fix(examples): update athena-workgroup example to the current module interface

### DIFF
--- a/examples/athena-workgroup/main.tf
+++ b/examples/athena-workgroup/main.tf
@@ -35,18 +35,25 @@ module "full" {
   enabled       = true
   force_destroy = true
 
-  client_config_enabled                     = false
   cloudwatch_metrics_enabled                = true
   query_on_s3_requester_pays_bucket_enabled = false
 
   per_query_data_usage_limit = 64 * 1024 * 1024
 
   query_result = {
-    s3_bucket          = "tedilabs-terraform-aws-data-examples-athena-workgroup"
-    s3_key_prefix      = "/athena-query-results"
-    encryption_enabled = true
-    encryption_mode    = "SSE_S3"
-    encryption_kms_key = null
+    management_mode        = "CUSTOMER_MANAGED"
+    override_client_config = true
+
+    customer_managed_query_result = {
+      s3_bucket = {
+        name       = "tedilabs-terraform-aws-data-examples-athena-workgroup"
+        key_prefix = "athena-query-results/"
+      }
+      encryption = {
+        enabled = true
+        mode    = "SSE_S3"
+      }
+    }
   }
 
   named_queries = [


### PR DESCRIPTION
## What & why

`examples/athena-workgroup` has been broken since `feat(athena-workgroup): support aws v6` (`abfcf88`), which reworked the `athena-workgroup` module interface but did not update its example. The example still passed the removed `client_config_enabled` variable and the old flat shape of `query_result`, so `terraform init` failed at config load with `Unsupported argument`. This PR updates the example call to the module's current interface. Every other `modules/*` and `examples/*` directory in the repo was audited and already passes `fmt` + `init` + `validate`; nothing else was touched.

## Validation matrix

`fmt` = `terraform fmt -check`, `init` = `terraform init -backend=false`, `validate` = `terraform validate`. Run per directory, with `.terraform`/`.terraform.lock.hcl` removed before and after each run. `terraform fmt -recursive -check .` at the repo root was clean before and after.

| Directory | fmt (before → after) | init (before → after) | validate (before → after) |
| --- | --- | --- | --- |
| `modules/athena-data-catalog` | OK → OK | OK → OK | OK → OK |
| `modules/athena-workgroup` | OK → OK | OK → OK | OK → OK |
| `modules/glue-connection` | OK → OK | OK → OK | OK → OK |
| `modules/glue-crawler` | OK → OK | OK → OK | OK → OK |
| `modules/glue-data-catalog` | OK → OK | OK → OK | OK → OK |
| `modules/glue-database` | OK → OK | OK → OK | OK → OK |
| `modules/glue-table` | OK → OK | OK → OK | OK → OK |
| `modules/lakeformation-data-catalog` | OK → OK | OK → OK | OK → OK |
| `modules/s3-access-point` | OK → OK | OK → OK | OK → OK |
| `modules/s3-bucket` | OK → OK | OK → OK | OK → OK |
| `modules/s3-objects` | OK → OK | OK → OK | OK → OK |
| `modules/s3-table` | OK → OK | OK → OK | OK → OK |
| `modules/s3-table-bucket` | OK → OK | OK → OK | OK → OK |
| `modules/s3-vector-bucket` | OK → OK | OK → OK | OK → OK |
| `examples/athena-workgroup` | OK → OK | **FAIL → OK** | **not reached → OK** |
| `examples/glue-data-catalog-full` | OK → OK | OK → OK | OK (warning) → OK (warning) |
| `examples/glue-data-catalog-simple` | OK → OK | OK → OK | OK → OK |
| `examples/s3-access-point-internet` | OK → OK | OK → OK | OK (warning) → OK (warning) |
| `examples/s3-access-point-vpc` | OK → OK | OK → OK | OK (warning) → OK (warning) |
| `examples/s3-bucket-access-logging` | OK → OK | OK → OK | OK → OK |
| `examples/s3-bucket-encryption` | OK → OK | OK → OK | OK → OK |
| `examples/s3-bucket-full` | OK → OK | OK → OK | OK → OK |
| `examples/s3-bucket-lifecycle-rules` | OK → OK | OK → OK | OK → OK |
| `examples/s3-bucket-objects` | OK → OK | OK → OK | OK → OK |
| `examples/s3-bucket-versioning` | OK → OK | OK → OK | OK → OK |
| `examples/s3-table-bucket` | OK → OK | OK → OK | OK → OK |
| `examples/s3-vector-bucket` | OK → OK | OK → OK | OK → OK |

`validate` for `examples/athena-workgroup` was not reachable before this PR because `init` failed during config load.

## Changes

### `examples/athena-workgroup` — `module "full"` used the pre-aws-v6 `athena-workgroup` interface

Before:

```hcl
  client_config_enabled                     = false
  cloudwatch_metrics_enabled                = true
  query_on_s3_requester_pays_bucket_enabled = false

  per_query_data_usage_limit = 64 * 1024 * 1024

  query_result = {
    s3_bucket          = "tedilabs-terraform-aws-data-examples-athena-workgroup"
    s3_key_prefix      = "/athena-query-results"
    encryption_enabled = true
    encryption_mode    = "SSE_S3"
    encryption_kms_key = null
  }
```

After:

```hcl
  cloudwatch_metrics_enabled                = true
  query_on_s3_requester_pays_bucket_enabled = false

  per_query_data_usage_limit = 64 * 1024 * 1024

  query_result = {
    management_mode        = "CUSTOMER_MANAGED"
    override_client_config = true

    customer_managed_query_result = {
      s3_bucket = {
        name       = "tedilabs-terraform-aws-data-examples-athena-workgroup"
        key_prefix = "athena-query-results/"
      }
      encryption = {
        enabled = true
        mode    = "SSE_S3"
      }
    }
  }
```

Reasons, all read off `modules/athena-workgroup/variables.tf` and `main.tf` at `main`:

- **`client_config_enabled` was removed and folded into `query_result.override_client_config`.** It is declared nowhere under `modules/`, which is what made `init` fail. Note the polarity flipped: the old module computed `enforce_workgroup_configuration = !var.client_config_enabled`, while the current one computes `enforce_workgroup_configuration = var.query_result.override_client_config`. The example's old `client_config_enabled = false` therefore means "enforce the workgroup configuration", which is expressed today as `override_client_config = true`. That is also the variable's default, but this is the "full configurations" example, so it is stated explicitly to keep demonstrating the setting rather than silently dropping it.
- **`query_result` is now a nested object.** `s3_bucket` / `s3_key_prefix` / `encryption_*` no longer exist as flat attributes; the customer-managed location moved under `query_result.customer_managed_query_result.{s3_bucket,encryption}`, and `management_mode` must be set to `CUSTOMER_MANAGED` for that block to be rendered at all (the default is `ATHENA_MANAGED`, which would have silently dropped the bucket the example demonstrates).
- **`key_prefix` had to be rewritten from `/athena-query-results` to `athena-query-results/`.** Two `validation` blocks on `query_result` now require, for `CUSTOMER_MANAGED`, that `s3_bucket.key_prefix` does not start with `/` and does end with `/`. The old value violated both, so a literal transcription of the old prefix would have failed `validate` even after the restructuring.
- **`encryption_kms_key = null` was dropped** rather than carried over as `kms_key = null`: `mode` is `SSE_S3`, the module only passes `kms_key` through for `SSE_KMS`/`CSE_KMS`, and the attribute already defaults to `null`.

The example's intent is unchanged — same workgroup names, same bucket, same SSE-S3 encryption, same named query, same limits.

## Still failing

Nothing. All 14 `modules/*` and all 13 `examples/*` directories pass `fmt`, `init -backend=false`, and `validate` after this PR.

Three example roots emit a non-fatal deprecation **warning** from the AWS provider, and are deliberately left alone:

```
Warning: Deprecated value used
  on main.tf line 11, in locals:
  11:   region     = data.aws_region.this.name
  The deprecation originates from data.aws_region.this.name
  name is deprecated. Use region instead.
```

- `examples/glue-data-catalog-full`
- `examples/s3-access-point-internet`
- `examples/s3-access-point-vpc`

These are pre-existing, `validate` still reports success, and switching `data.aws_region.this.name` to `.region` is a separate concern from this PR.

## Verification

- Full read-only audit of all 27 directories (14 `modules/*`, 13 `examples/*`) before any edit: `terraform fmt -check`, `terraform init -backend=false`, `terraform validate` in each, with `.terraform`/`.terraform.lock.hcl` cleaned between directories, plus `terraform fmt -recursive -check .` at the repo root.
- After the edit, `examples/athena-workgroup` was re-run from a clean state: `fmt -check` clean, `init -backend=false` succeeded, `validate` returned `Success! The configuration is valid.`
- Every argument of both `module "simple"` and `module "full"` in the example was checked against `modules/athena-workgroup/variables.tf`, including the nested attributes of `query_result` and `named_queries`.
- No markdown file in this repo contains an HCL example block calling a module (`grep -rn 'module "' --include='*.md'` finds nothing; the only `source =` hits in `*.md` are inside terraform-docs input tables), so there were no README examples to re-verify.
- Not verified: no `terraform plan` or `apply` was run, so this is config-load and type/validation-level correctness only. Nothing was checked against a live AWS account.
