### PR TITLE
fix(athena-workgroup): fix prepared statement resource key

### DIFF
--- a/modules/athena-workgroup/prepared-statements.tf
+++ b/modules/athena-workgroup/prepared-statements.tf
@@ -5,7 +5,7 @@
 resource "aws_athena_prepared_statement" "this" {
   for_each = {
     for statement in var.prepared_statements :
-    "${statement.database}:${statement.name}" => statement
+    statement.name => statement
   }
 
   region = var.region


### PR DESCRIPTION
## Summary

`aws_athena_prepared_statement` is a workgroup-scoped resource and the `prepared_statements` variable has no `database` attribute, so the `for_each` key referencing `statement.database` fails with an error whenever any prepared statement is provided (it only passed validation because the default is an empty list). Key by `statement.name` instead, which is unique within a workgroup.

No state migration is needed: the previous expression could never successfully create these resources, so no existing state can hold the old addresses.

_Note: this will have a trivial conflict with #105, which adds an engine-type guard to the same `for_each`._