### PR TITLE
fix(athena-workgroup): support `sts:SetContext` in trust policy of IAM Identity Center service role

### DIFF
--- a/modules/athena-workgroup/README.md
+++ b/modules/athena-workgroup/README.md
@@ -25,7 +25,7 @@ This module creates following resources.
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.12.0 |
-| <a name="module_role__iam_identity_center"></a> [role\_\_iam\_identity\_center](#module\_role\_\_iam\_identity\_center) | tedilabs/account/aws//modules/iam-role | ~> 0.33.0 |
+| <a name="module_role__iam_identity_center"></a> [role\_\_iam\_identity\_center](#module\_role\_\_iam\_identity\_center) | tedilabs/account/aws//modules/iam-role | ~> 0.33.11 |
 | <a name="module_role__spark"></a> [role\_\_spark](#module\_role\_\_spark) | tedilabs/account/aws//modules/iam-role | ~> 0.33.0 |
 
 ## Resources

--- a/modules/athena-workgroup/iam.tf
+++ b/modules/athena-workgroup/iam.tf
@@ -34,7 +34,7 @@ module "role__iam_identity_center" {
   count = (var.iam_identity_center.enabled && var.iam_identity_center.default_service_role.enabled) ? 1 : 0
 
   source  = "tedilabs/account/aws//modules/iam-role"
-  version = "~> 0.33.0"
+  version = "~> 0.33.11"
 
   name = coalesce(
     var.iam_identity_center.default_service_role.name,
@@ -60,6 +60,15 @@ module "role__iam_identity_center" {
       ]
     },
   ]
+  # INFO: The trust policy of the service role requires the `sts:SetContext`
+  # action to allow Athena to create identity-enhanced sessions for the IAM
+  # Identity Center users with trusted identity propagation.
+  trusted_session_context = {
+    enabled = true
+    allowed_context_providers = [
+      "arn:aws:iam::aws:contextProvider/IdentityCenter",
+    ]
+  }
 
   policies = var.iam_identity_center.default_service_role.policies
   inline_policies = merge(

--- a/modules/athena-workgroup/iam.tf
+++ b/modules/athena-workgroup/iam.tf
@@ -60,9 +60,7 @@ module "role__iam_identity_center" {
       ]
     },
   ]
-  # INFO: The trust policy of the service role requires the `sts:SetContext`
-  # action to allow Athena to create identity-enhanced sessions for the IAM
-  # Identity Center users with trusted identity propagation.
+  # INFO: The trust policy of the service role requires the `sts:SetContext` action to allow Athena to create identity-enhanced sessions for the IAM Identity Center users with trusted identity propagation.
   trusted_session_context = {
     enabled = true
     allowed_context_providers = [


### PR DESCRIPTION
## Summary

The default service role for IAM Identity Center enabled Athena workgroups (`role__iam_identity_center`) was missing the `sts:SetContext` action in its trust policy. AWS requires this action so that Athena can create identity-enhanced sessions that propagate IAM Identity Center user identities (trusted identity propagation) — without it, credential vending for TIP-enabled workgroups fails.

## Changes

- Enable `trusted_session_context` on the `role__iam_identity_center` module, restricted to the IAM Identity Center context provider (`arn:aws:iam::aws:contextProvider/IdentityCenter`) via the `sts:RequestContextProviders` condition key.
- Bump the `tedilabs/account/aws//modules/iam-role` version constraint for this role to `~> 0.33.11`, the release that introduced `trusted_session_context` support (tedilabs/terraform-aws-account#137).
- `role__spark` is intentionally left unchanged — trusted identity propagation is [not compatible with Athena for Spark workgroups](https://docs.aws.amazon.com/athena/latest/ug/workgroups-identity-center.html).

The resulting trust policy gains the following statement:

```json
{
  "Sid": "TrustedSessionContextForServices0",
  "Effect": "Allow",
  "Principal": { "Service": "athena.amazonaws.com" },
  "Action": "sts:SetContext",
  "Condition": {
    "ForAllValues:ArnLike": {
      "sts:RequestContextProviders": "arn:aws:iam::aws:contextProvider/IdentityCenter"
    }
  }
}
```

## References

- [Use IAM Identity Center enabled Athena workgroups](https://docs.aws.amazon.com/athena/latest/ug/workgroups-identity-center.html)
- [AWS blog — trusted identity propagation with Athena workgroups](https://aws.amazon.com/blogs/machine-learning/simplify-access-control-and-auditing-for-amazon-sagemaker-studio-using-trusted-identity-propagation/) (explicitly instructs adding `sts:SetContext` to the workgroup role's trust policy)